### PR TITLE
Improve `File` class initialzer with `URLConvertible`.

### DIFF
--- a/Kagee/Body.swift
+++ b/Kagee/Body.swift
@@ -42,15 +42,9 @@ public class JSON: Body {
 
 public class File: Body {
     let url: NSURL
-    public init(_ url: NSURL) {
-        self.url = url
-    }
     
-    public convenience init(string: String) {
-        guard let url = NSURL(string: string) else {
-            fatalError()
-        }
-        self.init(url)
+    public init(url urlConvertible: URLConvertible) {
+        self.url = urlConvertible.URL
     }
     
     public var data: ResponseData {

--- a/Kagee/MockPool.swift
+++ b/Kagee/MockPool.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class MockPool {
+class MockPool {
     static var mocks = [Mock]()
     
     class func add(mock: Mock) {

--- a/KageeTests/KageeTests.swift
+++ b/KageeTests/KageeTests.swift
@@ -155,7 +155,7 @@ class KageeTests: XCTestCase {
         
         let url = "/json_file"
         let fileUrl = NSBundle(forClass: self.dynamicType).URLForResource("test", withExtension: "json")!
-        Mock.install().request(url: url).response(200, body: File(fileUrl), header: nil)
+        Mock.install().request(url: url).response(200, body: File(url: fileUrl), header: nil)
         
         let request = NSURLRequest(URL: NSURL(string: url)!)
         let session = NSURLSession(configuration: NSURLSessionConfiguration.defaultSessionConfiguration())


### PR DESCRIPTION
If you think that `PatternA` is better than `PatternB(current)`, I fix so and push commit once again!

- `PatternA`

```swift
public class File: Body {
    let url: NSURL
    
    public init(_ urlConvertible: URLConvertible) {
        self.url = urlConvertible.URL
    }
}

// e.g.
let fileUrl = ...
File(fileUrl)
```

- `PatternB(current)`

```swift
public class File: Body {
    let url: NSURL
    
    public init(url urlConvertible: URLConvertible) {
        self.url = urlConvertible.URL
    }
}

// e.g.
let fileUrl = ...
File(url: fileUrl)
```